### PR TITLE
V8 0 6.5 trigger leg

### DIFF
--- a/CATConfig/CattupleConfig/corrections_v8-0-6.txt
+++ b/CATConfig/CattupleConfig/corrections_v8-0-6.txt
@@ -20,6 +20,10 @@
 ### MUON_MU24_TRIGGER_GH  TRIGGERFILEDIR EfficienciesAndSF_Period4.root IsoMu24_OR_IsoTkMu24_PtEtaBins/abseta_pt_ratio TH2F
 ### MUON_MU50_TRIGGER_BCDEF  TRIGGERFILEDIR EfficienciesAndSF_RunBtoF.root	Mu50_OR_TkMu50_PtEtaBins/abseta_pt_ratio TH2F
 ### MUON_MU50_TRIGGER_GH  TRIGGERFILEDIR EfficienciesAndSF_Period4.root	Mu50_OR_TkMu50_PtEtaBins/abseta_pt_ratio TH2F
+### MUON_MU17_TRIGGER_BCDEF TRIGGERFILEDIR  MuonTriggerEfficiency_TRILEP_DoubleIsoMu17Mu8_IsoMu17leg_RunBCDEF.root  TriggerEff_Trilepton_BCDEF  TH2F
+### MUON_MU8_OR_TKMU8_TRIGGER_BCDEF TRIGGERFILEDIR  MuonTriggerEfficiency_TRILEP_Mu8_OR_TkMu8_RunBCDEF.root TriggerEff_Trilepton_BCDEF  TH2F
+### MUON_MU17_TRIGGER_GH TRIGGERFILEDIR  MuonTriggerEfficiency_TRILEP_DoubleIsoMu17Mu8_IsoMu17leg_RunGH.root  TriggerEff_Trilepton_GH  TH2F
+### MUON_MU8_OR_TKMU8_TRIGGER_GH TRIGGERFILEDIR  MuonTriggerEfficiency_TRILEP_Mu8_OR_TkMu8_RunGH.root TriggerEff_Trilepton_GH  TH2F
 ### ID_BCDEF_MUON_HN_TRI_TIGHT IDFILEDIR MuonIDSF_TRILEP_RunBCDEF.root abseta_pt_PLOT TH2F
 ### ID_GH_MUON_HN_TRI_TIGHT IDFILEDIR MuonIDSF_TRILEP_RunGH.root abseta_pt_PLOT TH2F
 ### TRACKING_EFF IDFILEDIR Tracking_EfficienciesAndSF_BCDEFGH.root ratio_eff_eta3_dr030e030_corr TGraphAsymmErrors

--- a/LQAnalysis/AnalyzerTools/include/MCDataCorrections.h
+++ b/LQAnalysis/AnalyzerTools/include/MCDataCorrections.h
@@ -76,6 +76,10 @@ class MCDataCorrections{
   /// Trigger 
   double TriggerScaleFactor( std::vector<snu::KElectron> el, std::vector<snu::KMuon> mu, TString trigname, int direction=0);
   double TriggerScaleFactorPeriodDependant( std::vector<snu::KElectron> el, std::vector<snu::KMuon> mu, TString trigname, int catperiod, int direction=0);
+
+  double TriggerEfficiencyLegByLeg(std::vector<snu::KElectron> el, std::vector<snu::KMuon> mu, int TriggerCategory, int DataOrMC, int direction=0);
+  double TriggerEfficiencyLegByLegPeriodDependant(std::vector<snu::KElectron> el, std::vector<snu::KMuon> mu, int TriggerCategory, int catperiod, int DataOrMC, int direction=0);
+  double TriggerEfficiency_DiMuon_passing_DoubleMuonTrigger(snu::KMuon mu1, snu::KMuon mu2, TString leg1, TString leg2, int DataOrMC, int catperiod);
   
   
 

--- a/LQAnalysis/AnalyzerTools/src/MCDataCorrections.cc
+++ b/LQAnalysis/AnalyzerTools/src/MCDataCorrections.cc
@@ -725,11 +725,11 @@ double MCDataCorrections::TriggerEfficiency_DiMuon_passing_DoubleMuonTrigger(snu
     int bin_mu1 = hist_leg1->FindBin(eta1,pt1);
     int bin_mu2 = hist_leg1->FindBin(eta2,pt2);
 
-    double eff_mu1leg1 = hist_leg1->GetBinContent(bin_mu1);
-    double eff_mu2leg2 = hist_leg2->GetBinContent(bin_mu2);
+    double eff_mu1leg1 = hist_leg1->GetBinContent( hist_leg1->FindBin(eta1,pt1) );
+    double eff_mu2leg2 = hist_leg2->GetBinContent( hist_leg2->FindBin(eta2,pt2) );
 
-    double eff_mu1leg2 = hist_leg2->GetBinContent(bin_mu1);
-    double eff_mu2leg1 = hist_leg1->GetBinContent(bin_mu2);
+    double eff_mu1leg2 = hist_leg2->GetBinContent( hist_leg2->FindBin(eta1,pt1) );
+    double eff_mu2leg1 = hist_leg1->GetBinContent( hist_leg1->FindBin(eta2,pt2) );
 
     //cout << "[MCDataCorrections::TriggerEfficiency_DiMuon_passing_DoubleMuonTrigger] pt1 = " << pt1 << ", eta1 = " << eta1 << endl;
     //cout << "[MCDataCorrections::TriggerEfficiency_DiMuon_passing_DoubleMuonTrigger] => " << leg1 << " : " << eff_mu1leg1 << endl;

--- a/LQAnalysis/AnalyzerTools/src/MCDataCorrections.cc
+++ b/LQAnalysis/AnalyzerTools/src/MCDataCorrections.cc
@@ -709,9 +709,11 @@ double MCDataCorrections::TriggerEfficiency_DiMuon_passing_DoubleMuonTrigger(snu
   double eta1 = abs(mu1.Eta());
   double pt1 = mu1.Pt();
   if(pt1>=120.) pt1 = 119.;
+  if(pt1<10.) pt1 = 10.1;
   double eta2 = abs(mu2.Eta());
   double pt2 = mu2.Pt();
   if(pt2>120.) pt2 = 119.;
+  if(pt2<10.) pt2 = 10.1;
 
   //cout << "[MCDataCorrections::TriggerEfficiency_DiMuon_passing_DoubleMuonTrigger] tag = " << tag << ", sample = " << sample << endl;
 

--- a/LQAnalysis/Analyzers/include/AnalyzerCore.h
+++ b/LQAnalysis/Analyzers/include/AnalyzerCore.h
@@ -339,6 +339,7 @@ class AnalyzerCore : public LQCycleBase {
   bool GenMatching(snu::KParticle a, snu::KParticle b, double maxDeltaR, double maxPtDiff);
   std::vector<snu::KMuon> GetHNTriMuonsByLooseRelIso(double LooseRelIsoMax, bool keepfake);
   void PrintTruth();
+  std::vector<snu::KMuon> sort_muons_ptorder(std::vector<snu::KMuon> muons);
 
   
 };

--- a/LQAnalysis/Analyzers/src/AnalyzerCore.cc
+++ b/LQAnalysis/Analyzers/src/AnalyzerCore.cc
@@ -2742,6 +2742,26 @@ TNtupleD* AnalyzerCore::GetNtp(TString hname){
   return n;
 }
 
+std::vector<snu::KMuon> AnalyzerCore::sort_muons_ptorder(std::vector<snu::KMuon> muons){
+
+  std::vector<snu::KMuon> outmuon;
+  while(outmuon.size() != muons.size()){
+    double this_maxpt = 0.;
+    int index(0);
+    for(unsigned int i=0; i<muons.size(); i++){
+      bool isthisused = std::find( outmuon.begin(), outmuon.end(), muons.at(i) ) != outmuon.end();
+      if(isthisused) continue;
+      if( muons.at(i).Pt() > this_maxpt ){
+        index = i;
+        this_maxpt = muons.at(i).Pt();
+      }
+    }
+    outmuon.push_back( muons.at(index) );
+  }
+  return outmuon;
+ 
+
+}
 
 
 


### PR DESCRIPTION
1) Mu17 and Mu8 dimuon trigger scale factor function added.
usage in the analyzer : 
  double trigger_sf = 1.;
  if(!k_isdata){
    double trigger_eff_Data = mcdata_correction->TriggerEfficiencyLegByLeg(electrontriLooseColl, muontriLooseColl, 0, 0, 0);
    double trigger_eff_MC = mcdata_correction->TriggerEfficiencyLegByLeg(electrontriLooseColl, muontriLooseColl, 0, 1, 0);
    trigger_sf = trigger_eff_Data/trigger_eff_MC;
  }
2) muon sorting function added
rarely, muon collection is not pt-ordered, after rochestor correction, so I just made a function inside AnalzyerCore to sort them.