### PR TITLE
dxy method muon FR gets scale factor applied histogram

### DIFF
--- a/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/HNCommonLeptonFakes/HNCommonLeptonFakes.h
+++ b/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/HNCommonLeptonFakes/HNCommonLeptonFakes.h
@@ -122,7 +122,7 @@ class HNCommonLeptonFakes {
   void SetNJet(int nj);
   void SetNBJet(int nbj);
   //==== get PR/FR
-  float getTrilepFakeRate_muon(bool geterr, float pt,  float eta, bool applysf=true);
+  float getTrilepFakeRate_muon(bool geterr, float pt,  float eta);
   float getTrilepPromptRate_muon(bool geterr, float pt, float eta);
   //==== get weight
   float get_dilepton_mm_eventweight(bool geterr, std::vector<TLorentzVector> muons, bool isT1, bool isT2);


### PR DESCRIPTION
Before, we save FR and FRSF both, and then multiply them.

But since we don't have to have them separtely, we only save the multiplied one.