### PR TITLE
V8 0 7.12 half sample syst

### DIFF
--- a/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/HNCommonLeptonFakes/HNCommonLeptonFakes.h
+++ b/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/HNCommonLeptonFakes/HNCommonLeptonFakes.h
@@ -137,6 +137,8 @@ class HNCommonLeptonFakes {
   //==== After runing get_eventweight, we have # of Loose but not Tight
   int GetNLooseNotTight();
 
+  void SetUsePtCone(bool b);
+
  private:
   /// vector for storing FakeCR strings
   std::vector<TString> regions;
@@ -181,6 +183,7 @@ class HNCommonLeptonFakes {
   int n_jet, n_bjet;
   std::vector<double> dXYMins, RelIsoMaxs;
   int n_Loose_not_Tight;
+  bool UsePtCone;
 
 };
 #endif

--- a/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/HNCommonLeptonFakes/HNCommonLeptonFakes.h
+++ b/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/HNCommonLeptonFakes/HNCommonLeptonFakes.h
@@ -129,7 +129,7 @@ class HNCommonLeptonFakes {
   //==== get weight
   float get_dilepton_mm_eventweight(bool geterr, std::vector<TLorentzVector> muons, bool isT1, bool isT2);
   float get_trilepton_mmm_eventweight(bool geterr, std::vector<TLorentzVector> muons, bool isT1, bool isT2, bool isT3);
-  float get_eventweight(bool geterr, std::vector<TLorentzVector> muons, TString muid, std::vector<TLorentzVector> electrons, std::vector<TString> elid, std::vector<bool> isT);
+  float get_eventweight(bool geterr, std::vector<TLorentzVector> muons, TString muid, std::vector<TLorentzVector> electrons, std::vector<TString> elid, std::vector<bool> isT, int HalfSampleErrorDir=0);
 
   //==== Large dXYSig working poins
   std::vector<double> GetdXYMins();

--- a/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/Root/HNCommonLeptonFakes.cxx
+++ b/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/Root/HNCommonLeptonFakes.cxx
@@ -293,6 +293,10 @@ void HNCommonLeptonFakes::InitialiseFake(){
   FRnjets.push_back("withjet");
   FRnjets.push_back("0bjet");
   FRnjets.push_back("withbjet");
+
+  vector<TString> xyvars;
+  xyvars.push_back("pt_vs_eta");
+  xyvars.push_back("pt_cone_vs_eta");
   
   for(int i=0; i<N_dXYMin; i++){
     for(int j=0; j<N_LooseRelIso; j++){
@@ -302,8 +306,14 @@ void HNCommonLeptonFakes::InitialiseFake(){
 
         TString this_njet = FRnjets.at(k);
 
-        _2DEfficiencyMap_Double["MUON_FR_"+this_wp+"_"+this_njet] = dynamic_cast<TH2D*>((file_trilep_fake->Get(this_wp+"_FR_"+this_njet+"_sfed"))->Clone());
-        _2DEfficiencyMap_Double["MUON_FR_QCD_"+this_wp+"_"+this_njet] = dynamic_cast<TH2D*>((file_trilep_fake->Get(this_wp+"_FR_QCD_"+this_njet))->Clone());
+        for(unsigned int l=0;l<xyvars.size(); l++){
+
+          TString xyvar = xyvars.at(l);
+
+          _2DEfficiencyMap_Double["MUON_FR_"+this_wp+"_"+this_njet+"_"+xyvar] = dynamic_cast<TH2D*>((file_trilep_fake->Get(this_wp+"_FR_"+this_njet+"_sfed_"+xyvar))->Clone());
+          _2DEfficiencyMap_Double["MUON_FR_QCD_"+this_wp+"_"+this_njet+"_"+xyvar] = dynamic_cast<TH2D*>((file_trilep_fake->Get(this_wp+"_FR_QCD_"+this_njet+"_"+xyvar))->Clone());
+
+        }
 
       }
     }
@@ -375,6 +385,7 @@ HNCommonLeptonFakes::HNCommonLeptonFakes(std::string path,bool usegev){
   DataPeriod = "B";
   n_jet = -999;
   n_bjet = -999;
+  UsePtCone = false;
 }
 
 
@@ -615,19 +626,19 @@ float HNCommonLeptonFakes::getFakeRate_electronEta(int sys,float pt, float eta, 
   TString hist = "fake_el_eff_";
   hist += cut;
   
-  cout << hist << endl;
+  //cout << hist << endl;
 
-  for(map<TString, TH2D*>::iterator mit = _2DEfficiencyMap_Double.begin(); mit != _2DEfficiencyMap_Double.end(); mit++){
-    cout << mit->first <<" " << mit->second << endl;
-  }
+  //for(map<TString, TH2D*>::iterator mit = _2DEfficiencyMap_Double.begin(); mit != _2DEfficiencyMap_Double.end(); mit++){
+    //cout << mit->first <<" " << mit->second << endl;
+  //}
 
   //cout << hist << endl;
   mapit = _2DEfficiencyMap_Double.find(hist.Data());
   if(mapit!=_2DEfficiencyMap_Double.end()){
-    cout << mapit->second << endl;
+    //cout << mapit->second << endl;
     
     int binx =  mapit->second->FindBin(pt,fabs(eta));
-    cout << binx << endl;
+    //cout << binx << endl;
     eff_fake =  mapit->second->GetBinContent(binx);
     //cout << "eff_fake = " << eff_fake << endl;
     if(sys != 0) return mapit->second->GetBinError(binx); 
@@ -939,6 +950,13 @@ float HNCommonLeptonFakes::getTrilepFakeRate_muon(bool geterr, float pt,  float 
     cout << "[HNCommonLeptonFakes::getTrilepFakeRate_muon] ??" << endl;
   }
 
+  if(UsePtCone){
+    wp += "_pt_cone_vs_eta";
+  }
+  else{
+    wp += "_pt_vs_eta";
+  }
+
   //cout << "n_jet = " << n_jet << endl;
   //cout << "n_bjet = " << n_bjet << endl;
   //cout << "==>wp = " << wp << endl;
@@ -1036,6 +1054,12 @@ std::vector<double> HNCommonLeptonFakes::GetRelIsoMaxs(){
 int HNCommonLeptonFakes::GetNLooseNotTight(){
 
   return n_Loose_not_Tight;
+
+}
+
+void HNCommonLeptonFakes::SetUsePtCone(bool b){
+
+  UsePtCone = b;
 
 }
 

--- a/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/Root/HNCommonLeptonFakes.cxx
+++ b/LQAnalysis/AnalyzerTools/HNCommonLeptonFakes/Root/HNCommonLeptonFakes.cxx
@@ -1259,7 +1259,7 @@ TDirectory* HNCommonLeptonFakes::getTemporaryDirectory(void) const
   return tempDir;
 }
 
-float HNCommonLeptonFakes::get_eventweight(bool geterr, std::vector<TLorentzVector> muons, TString muid, std::vector<TLorentzVector> electrons, vector<TString> elcut, std::vector<bool> isT){
+float HNCommonLeptonFakes::get_eventweight(bool geterr, std::vector<TLorentzVector> muons, TString muid, std::vector<TLorentzVector> electrons, vector<TString> elcut, std::vector<bool> isT, int HalfSampleErrorDir){
 
   unsigned int n_leptons = isT.size();
 
@@ -1305,6 +1305,22 @@ float HNCommonLeptonFakes::get_eventweight(bool geterr, std::vector<TLorentzVect
       if(elcut.size()==1)        fr_err.push_back( getFakeRate_electronEta(1, lep_pt.at(i), lep_eta.at(i),  elcut[0]));
       else   fr_err.push_back( getFakeRate_electronEta(1, lep_pt.at(i), lep_eta.at(i),  elcut[1]));
       pr_err.push_back( getEfficiency_electron(1, lep_pt.at(i), lep_eta.at(i)) );
+    }
+  }
+
+  //==== if HalfSampleErrorDir!=0,
+  //==== assign "5 %" HalfSampleTest Systematic Uncertainty
+
+  if(HalfSampleErrorDir>0){
+    for(unsigned int i=0; i<fr.size(); i++){
+      fr.at(i)     = fr.at(i)    *(1.+0.05);
+      fr_err.at(i) = fr_err.at(i)*(1.+0.05);
+    }
+  }
+  else if(HalfSampleErrorDir<0){
+    for(unsigned int i=0; i<fr.size(); i++){
+      fr.at(i)     = fr.at(i)    *(1.-0.05);
+      fr_err.at(i) = fr_err.at(i)*(1.-0.05);
     }
   }
 

--- a/LQAnalysis/AnalyzerTools/include/DataDrivenBackgrounds.h
+++ b/LQAnalysis/AnalyzerTools/include/DataDrivenBackgrounds.h
@@ -88,6 +88,10 @@ class DataDrivenBackgrounds{
 
   // Class object to get event weights for Fakes
 
+  //==== Use pt-cone-corrected
+  void SetUsePtCone(bool b);
+  double MuonConePt(snu::KMuon muon, double tightiso);
+
   /// GENERAL FUNCTIONS
   std::vector<TLorentzVector> MakeTLorentz( std::vector<snu::KElectron> el);
   std::vector<TLorentzVector> MakeTLorentz( std::vector<snu::KMuon> mu);
@@ -105,6 +109,7 @@ class DataDrivenBackgrounds{
 
   HNCommonLeptonFakes* m_fakeobj;
   EventBase* dd_eventbase;
+  bool UsePtCone;
 
 
 

--- a/LQAnalysis/AnalyzerTools/include/DataDrivenBackgrounds.h
+++ b/LQAnalysis/AnalyzerTools/include/DataDrivenBackgrounds.h
@@ -77,7 +77,7 @@ class DataDrivenBackgrounds{
   TString GetElFRKey(TString elidloose, TString elidtight, TString method);
   std::vector<TString> GetElFRKey( TString IDloose,TString IDtight, TString method, std::vector<TString> regs1);
   //==== General lepton fakes
-  float Get_DataDrivenWeight(bool geterr, std::vector<snu::KMuon> k_muons, TString muid, int n_muons, std::vector<snu::KElectron> k_electrons, TString elid, int n_electrons, TString elidloose="ELECTRON16_POG_FAKELOOSE", TString method="dijet_ajet40");
+  float Get_DataDrivenWeight(bool geterr, std::vector<snu::KMuon> k_muons, TString muid, int n_muons, std::vector<snu::KElectron> k_electrons, TString elid, int n_electrons, TString elidloose="ELECTRON16_POG_FAKELOOSE", TString method="dijet_ajet40", int HalfSampleErrorDir=0);
 
   /// = single lepton
   float Get_DataDrivenWeight_E(bool geterr, std::vector<snu::KElectron> k_electrons ,TString ID, TString method);

--- a/LQAnalysis/AnalyzerTools/src/DataDrivenBackgrounds.cc
+++ b/LQAnalysis/AnalyzerTools/src/DataDrivenBackgrounds.cc
@@ -24,6 +24,7 @@
    string lqdir = getenv("LQANALYZER_DIR");
    m_fakeobj = new HNCommonLeptonFakes(lqdir+"/LQAnalysis/src/HNCommonLeptonFakes/share/");
    dd_eventbase= 0;
+   UsePtCone=false;
 
 
  }
@@ -372,6 +373,8 @@
      return 0.;
    }
 
+   m_fakeobj->SetUsePtCone(UsePtCone);
+
    std::vector<TLorentzVector> muons=MakeTLorentz(k_muons);
    std::vector<TLorentzVector> electrons=MakeTLorentz(k_electrons);
    std::vector<TString> vkeys;
@@ -619,6 +622,20 @@ TString DataDrivenBackgrounds::GetElFRKey( TString IDloose,TString IDtight, TStr
 
 /// MISC FUNCTIONS
 
+void DataDrivenBackgrounds::SetUsePtCone(bool b){
+
+  UsePtCone = b;
+
+}
+
+double DataDrivenBackgrounds::MuonConePt(snu::KMuon muon, double tightiso){
+
+  double mu_pt_corr = muon.Pt()*(1+max(0.,(muon.RelIso04()-tightiso))) ;
+
+  return mu_pt_corr;
+
+}
+
 vector<TLorentzVector> DataDrivenBackgrounds::MakeTLorentz(vector<snu::KElectron> el){
 
   vector<TLorentzVector> tl_el;
@@ -635,7 +652,13 @@ vector<TLorentzVector> DataDrivenBackgrounds::MakeTLorentz(vector<snu::KMuon> mu
   vector<TLorentzVector> tl_mu;
   for(vector<KMuon>::iterator itmu=mu.begin(); itmu!=mu.end(); ++itmu) {
     TLorentzVector tmp_mu;
-    tmp_mu.SetPtEtaPhiM((*itmu).Pt(),(*itmu).Eta(),(*itmu).Phi(),(*itmu).M());
+    double this_pt = (*itmu).Pt();
+
+    if(UsePtCone){
+      this_pt = MuonConePt((*itmu), 0.1);
+    }
+
+    tmp_mu.SetPtEtaPhiM(this_pt,(*itmu).Eta(),(*itmu).Phi(),(*itmu).M());
     tl_mu.push_back(tmp_mu);
   }
   return tl_mu;

--- a/LQAnalysis/AnalyzerTools/src/DataDrivenBackgrounds.cc
+++ b/LQAnalysis/AnalyzerTools/src/DataDrivenBackgrounds.cc
@@ -336,7 +336,7 @@
    return mmm_weight;
  }
 
- float DataDrivenBackgrounds::Get_DataDrivenWeight(bool geterr, std::vector<snu::KMuon> k_muons, TString muid, int n_muons, std::vector<snu::KElectron> k_electrons, TString elid, int n_electrons, TString elidloose, TString elmethod){
+ float DataDrivenBackgrounds::Get_DataDrivenWeight(bool geterr, std::vector<snu::KMuon> k_muons, TString muid, int n_muons, std::vector<snu::KElectron> k_electrons, TString elid, int n_electrons, TString elidloose, TString elmethod, int HalfSampleErrorDir){
 
    float this_weight = 0.;
 
@@ -387,7 +387,7 @@
 
 
    std::vector<TString> elkeys = GetElFRKey(elidloose, elid, elmethod, vkeys);
-   this_weight =m_fakeobj->get_eventweight(geterr, muons, muid, electrons,  elkeys , isT);
+   this_weight =m_fakeobj->get_eventweight(geterr, muons, muid, electrons,  elkeys , isT, HalfSampleErrorDir);
 
    return this_weight;
  }


### PR DESCRIPTION
1) FakeRate HalfSampleTest systematic added. Default arguments are set to 0, so analyzer codes won't be affected.

2) FR with "pt-cone vs eta" added
Inside the analyzer,

m_datadriven_bkg->SetUsePtCone(true);

will get "pt-cone vs eta" histogram.
Default is "pt vs eta"